### PR TITLE
Debugging two issues inside load_in_mixCifar_data function 

### DIFF
--- a/CIFAR/make_datasets.py
+++ b/CIFAR/make_datasets.py
@@ -267,7 +267,7 @@ def load_in_mixCifar_data(in_dset, rng, alpha, cortype):
     train_len = int(alpha * len(train_data_in_orig_cifar))
     train_idx = idx[:train_len]
     
-    aux_idx = idx[int(0.5*len(train_data_in_orig_cifar)):]
+    aux_idx = idx[int((1-alpha)*len(train_data_in_orig_cifar)):]
 
     train_in_data = torch.utils.data.Subset(train_data_in_orig_cifar, train_idx)
 

--- a/CIFAR/make_datasets.py
+++ b/CIFAR/make_datasets.py
@@ -271,7 +271,7 @@ def load_in_mixCifar_data(in_dset, rng, alpha, cortype):
 
     train_in_data = torch.utils.data.Subset(train_data_in_orig_cifar, train_idx)
 
-    aux_in_data = torch.utils.data.Subset(train_data_in_orig_cifar, aux_idx)
+    aux_in_data = torch.utils.data.Subset(aux_data_cor_orig, aux_idx)
 
     idx_cor = np.array(range(len(aux_data_cor_orig)))
     rng.shuffle(idx)


### PR DESCRIPTION
I have change load_in_mixCifar_data function inside make_dataset.py file.
1- While creating aux_idx_cor indices the parameter that multiply inside len(aux_data_cor_orig) is 0.5 which if I change alpha in run.sh file it will not affect how much aux_in_data will be inside training data.
2- When trying to create aux_in_data I incorrectly you are creating a subset from train_data_in_orig_cifar instead of aux_data_cor_orig.

Thanks for your consideration.